### PR TITLE
Fixed variable definitions

### DIFF
--- a/src/sbdynt.py
+++ b/src/sbdynt.py
@@ -668,9 +668,9 @@ def run_tno(des=None, clones=None, datadir='', archivefile=None,
             writelog(logf,logmessage) 
             if(logf != 'screen'):
                 print(logmessage)
-            tno_results.proper_elements.proper_elements.a = tno_class.features.a_mean
-            tno_results.proper_elements.proper_elements.e = tno_class.features.e_mean
-            tno_results.proper_elements.proper_elements.sinI = np.sin(tno_class.features.i_mean)
+            tno_results.proper_elements.proper_elements['a'] = tno_class.features.a_mean
+            tno_results.proper_elements.proper_elements['e'] = tno_class.features.e_mean
+            tno_results.proper_elements.proper_elements['sinI'] = np.sin(tno_class.features.i_mean)
         
             return 2, tno_results, sim
         


### PR DESCRIPTION
The proper_elements.proper_elements variable is a dictionary, not a class object, so this creates a bug for scattering objects after ML classification in proper elements computation is also done.